### PR TITLE
Rename extension to "Hide Whitespace for GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# GitHub Whitespace Chrome Extension
+# Hide Whitespace for GitHub — Chrome Extension
 
 <img src="https://github.com/jackchuka/chrome-extension-github-whitespace/blob/master/public/icon128.png?raw=true" alt="logo" width="64"/>
 
-Redirect GitHub pull request pages to ignore whitespaces
+Hide whitespace-only changes in GitHub pull request diffs.
+
+> This is an independent, open-source extension. It is not affiliated with, endorsed by, or sponsored by GitHub, Inc. "GitHub" is a trademark of GitHub, Inc.
 
 ## Built Based On
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "name": "GitHub Whitespace",
-  "description": "Redirect GitHub pull request pages to ignore whitespaces",
+  "name": "Hide Whitespace for GitHub",
+  "description": "Hide whitespace-only changes in GitHub pull request diffs. Independent extension, not affiliated with GitHub.",
   "version": "<<NPM_VERSION>>",
   "background": {
     "service_worker": "js/service_worker.js"


### PR DESCRIPTION
Renames the extension and refreshes its store-facing copy.

## Changes
- `public/manifest.json`: `name` → **Hide Whitespace for GitHub**; rewrote `description` (109 chars, within the 132 limit) and added an independence disclaimer.
- `README.md`: updated title and tagline; added a non-affiliation / trademark notice.

## Notes
- Store listing title/description and icon/screenshots still need to be updated separately in the Chrome Web Store Developer Dashboard.
- `dist/` is gitignored and regenerates from `public/` on build.