### PR TITLE
ci: run production build in PR test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Format check
         run: pnpm run fmt -- --check .
 
+      - name: Build
+        run: pnpm run build
+
       - name: Run tests
         run: pnpm test


### PR DESCRIPTION
## Why

The webpack/`ts-loader` production build only ran in `release.yml` (on tag). PR CI (`test.yml`) ran lint + format + a no-op test, so a change could pass PR CI while the build was broken.

This gap was hit by the **TypeScript 7 bump (#97)**: PR CI is green, but `pnpm run build` fails because `ts-loader@9.6.2` calls into the TS compiler API that TS 7.0 removed:

```
ERROR in ./src/content_script.ts
Module build failed (from ts-loader):
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at findConfigFile (ts-loader/dist/config.js:105:30)
```

## Change

Add a `Build` step (`pnpm run build`) to the PR test workflow, so build-breaking changes are caught before merge.

Verified locally: build passes on `master` (TS 6.0.3) and fails on the #97 branch (TS 7.0.2).