### PR TITLE
feat: patch links to include `?w=1`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log
 node_modules/
 dist/
 tmp/
+.idea/

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -1,10 +1,28 @@
 (function () {
+  // Check if we're on a pull request "Files changed" page.
+  // GitHub may use either `/files` or `/changes` for this tab.
+  const PR_DIFF_PATH_PATTERN = /^\/[^/]+\/[^/]+\/pull\/\d+\/(?:files|changes)(?:\/|$)/;
+
+  // Add 'w=1' to the end of relevant links, so we don't need to redirect as a separate step after navigating
+  function patchLinks() {
+    for (const anchor of document.querySelectorAll<HTMLAnchorElement>("a[href]")) {
+      const url = new URL(anchor.href);
+
+      if (PR_DIFF_PATH_PATTERN.test(url.pathname) && url.searchParams.get("w") !== "1") {
+        // Add 'w=1' to the link
+        url.searchParams.set("w", "1");
+        anchor.href = url.toString();
+
+        // Stop event propagation after the click, so React Router doesn't do its own redirect
+        anchor.addEventListener("click", (event) => event.stopPropagation(), { capture: true });
+      }
+    }
+  }
+
   function redirectIfNecessary() {
     const url = new URL(window.location.href);
 
-    // Check if we're on a pull request "Files changed" page
-    // GitHub may use either `/files` or `/changes` for this tab.
-    if (/^\/[^/]+\/[^/]+\/pull\/\d+\/(?:files|changes)(?:\/|$)/.test(url.pathname)) {
+    if (PR_DIFF_PATH_PATTERN.test(url.pathname)) {
       // If 'w=1' is not present, add it
       if (url.searchParams.get("w") !== "1") {
         url.searchParams.set("w", "1");
@@ -14,6 +32,7 @@
   }
 
   redirectIfNecessary();
+  patchLinks();
 
   let lastUrl = window.location.href;
   new MutationObserver(() => {
@@ -22,5 +41,6 @@
       lastUrl = currentUrl;
       redirectIfNecessary();
     }
+    patchLinks();
   }).observe(document, { subtree: true, childList: true });
 })();


### PR DESCRIPTION
If you're on the homepage of a PR (e.g. https://github.com/organization/repo/pull/1234) and you click the "Files changed" tab, the page first loads like normal, and then refreshes to add the `?w=1` in the url.

This PR fixes that issue so that only one page load is needed, by editing all relevant links to include the `?w=1` at the end.