### PR TITLE
Add Github repo link to homepage_url in the manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,6 +3,7 @@
   "name": "Hide Whitespace for GitHub",
   "description": "Hide whitespace-only changes in GitHub pull request diffs. Independent extension, not affiliated with GitHub.",
   "version": "<<NPM_VERSION>>",
+  "homepage_url": "https://github.com/jackchuka/chrome-extension-github-whitespace",
   "background": {
     "service_worker": "js/service_worker.js"
   },


### PR DESCRIPTION
This should add a link to the Github repo on the extension's page in the Chrome store