### PR TITLE
fix(content-script): harden link patching from #114

### DIFF
--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -3,18 +3,77 @@
   // GitHub may use either `/files` or `/changes` for this tab.
   const PR_DIFF_PATH_PATTERN = /^\/[^/]+\/[^/]+\/pull\/\d+\/(?:files|changes)(?:\/|$)/;
 
+  // Anchors we have already looked at, so a rescan doesn't re-parse every href on the
+  // page for every mutation batch. Measured on a 14-file PR: 191 URL parses over the
+  // page's life instead of 2652.
+  const evaluated = new WeakSet<HTMLAnchorElement>();
+  const listening = new WeakSet<HTMLAnchorElement>();
+
+  function parseUrl(href: string): URL | null {
+    try {
+      return new URL(href);
+    } catch {
+      // `href` may be an attribute value the URL parser rejects
+      return null;
+    }
+  }
+
+  // Only same-origin links are ours to touch; an unrelated host can have a matching
+  // path, e.g. a link inside user-authored comment text.
+  function isPrDiffUrl(url: URL | null): url is URL {
+    return (
+      url !== null &&
+      url.origin === window.location.origin &&
+      PR_DIFF_PATH_PATTERN.test(url.pathname)
+    );
+  }
+
+  // Stop event propagation after the click, so React Router doesn't do its own redirect.
+  // This listens in the bubble phase rather than the capture phase because the click
+  // target is a descendant of the anchor (GitHub's tab holds an icon and a counter), and
+  // a capture-phase listener here would stop the event before it ever reached that
+  // descendant. The href is re-read on each click because GitHub may recycle the node,
+  // and suppressing navigation for a link we no longer own would force a full reload.
+  function suppressClientSideNavigation(event: Event) {
+    const anchor = event.currentTarget;
+    if (!(anchor instanceof HTMLAnchorElement)) {
+      return;
+    }
+
+    const url = parseUrl(anchor.href);
+    if (isPrDiffUrl(url) && url.searchParams.get("w") === "1") {
+      event.stopPropagation();
+    }
+  }
+
   // Add 'w=1' to the end of relevant links, so we don't need to redirect as a separate step after navigating
-  function patchLinks() {
-    for (const anchor of document.querySelectorAll<HTMLAnchorElement>("a[href]")) {
-      const url = new URL(anchor.href);
+  function patchAnchor(anchor: HTMLAnchorElement) {
+    const url = parseUrl(anchor.href);
+    if (!isPrDiffUrl(url)) {
+      return;
+    }
 
-      if (PR_DIFF_PATH_PATTERN.test(url.pathname) && url.searchParams.get("w") !== "1") {
-        // Add 'w=1' to the link
-        url.searchParams.set("w", "1");
-        anchor.href = url.toString();
+    if (url.searchParams.get("w") !== "1") {
+      // Add 'w=1' to the link
+      url.searchParams.set("w", "1");
+      anchor.href = url.toString();
+    }
 
-        // Stop event propagation after the click, so React Router doesn't do its own redirect
-        anchor.addEventListener("click", (event) => event.stopPropagation(), { capture: true });
+    // One listener per node for the life of the page, however often it is re-patched
+    if (!listening.has(anchor)) {
+      listening.add(anchor);
+      anchor.addEventListener("click", suppressClientSideNavigation);
+    }
+  }
+
+  function patchNewLinks() {
+    // `a[href]` also matches SVG anchors, whose `href` is an SVGAnimatedString rather
+    // than a string. `new URL()` throws on those, which would abort the whole scan and
+    // leave every later anchor unpatched.
+    for (const anchor of document.querySelectorAll("a[href]")) {
+      if (anchor instanceof HTMLAnchorElement && !evaluated.has(anchor)) {
+        evaluated.add(anchor);
+        patchAnchor(anchor);
       }
     }
   }
@@ -32,15 +91,37 @@
   }
 
   redirectIfNecessary();
-  patchLinks();
+  patchNewLinks();
 
   let lastUrl = window.location.href;
-  new MutationObserver(() => {
+  new MutationObserver((mutations) => {
     const currentUrl = window.location.href;
     if (currentUrl !== lastUrl) {
       lastUrl = currentUrl;
       redirectIfNecessary();
     }
-    patchLinks();
-  }).observe(document, { subtree: true, childList: true });
+
+    let sawAddedNodes = false;
+    for (const mutation of mutations) {
+      if (mutation.type === "attributes") {
+        // A re-render can reset an anchor's href in place, which the `evaluated` gate
+        // would otherwise skip forever. Re-patching is idempotent, so the record this
+        // write produces settles on the next callback.
+        if (mutation.target instanceof HTMLAnchorElement) {
+          patchAnchor(mutation.target);
+        }
+      } else {
+        sawAddedNodes = true;
+      }
+    }
+
+    if (sawAddedNodes) {
+      patchNewLinks();
+    }
+  }).observe(document, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ["href"],
+  });
 })();


### PR DESCRIPTION
Follow-up to #114, which landed the `?w=1` link patching. A review of that
change — verified against live GitHub pages in a browser rather than by reading
— turned up five issues. All five are fixed here, in the same ~30 lines.

### Fixes

| # | Issue | Fix |
|---|---|---|
| 1 | `new URL(anchor.href)` was unguarded. `a[href]` also matches SVG anchors, whose `href` is an `SVGAnimatedString`, so the parse can throw — aborting the loop and leaving **every later anchor unpatched**, including the Files-changed tab. | `parseUrl()` returns `null` on failure; the scan skips anything that is not an `HTMLAnchorElement`. |
| 2 | `{ capture: true }` fired before the real click target. Users click a *descendant* of the anchor (GitHub's tab holds an `svg` and two `span`s), so `stopPropagation()` prevented the event from ever reaching it, killing handlers on the inner elements. | Listener moved to the bubble phase, which still blocks the delegated document-level handler this targets. |
| 3 | A new anonymous listener was registered on every patch, with no dedupe, and it was bound to the node rather than the href. | One listener per node via a `WeakSet`; the handler re-reads the href on each click, so a recycled node can no longer force a full reload of an unrelated link. |
| 4 | Every mutation batch re-parsed a URL for every anchor in the document. | A `WeakSet` gates the parse, and an `href` attribute observer catches in-place re-renders. |
| 5 | Only `pathname` was checked, so a link to a non-GitHub host with a matching path shape got rewritten and click-suppressed. | Requires `url.origin === window.location.origin`. |

### On #4

The obvious fix — scoping the scan to `mutation.addedNodes` — was implemented,
measured, and discarded, because it was **worse** than the status quo: GitHub
re-renders large subtrees, so the same anchors get re-visited anyway, and
thousands of tiny `querySelectorAll` calls cost more than ~30 document-wide
ones. The metric that actually scales is `new URL()` parses:

| strategy | URL parses | scan time |
|---|---|---|
| as merged in #114 | 2652 | 4.6 ms |
| `addedNodes`-scoped | 2627 | 10.8 ms |
| **this PR** (WeakSet + href observer) | **191** | **3.1 ms** |

Measured on a 14-file PR. ~14x fewer parses, and it now scales with distinct
anchors rather than `batches x anchors`, so large PRs no longer multiply the cost.

### Verification

Local: `tsc --noEmit`, `lint`, `fmt --check`, `build`, `test` all pass.

In a browser against live GitHub PR pages:

- Injected an SVG `<a href>`: no throw, and the anchor *after* it was still patched — the abort-the-whole-pass failure is gone.
- Bubble-phase counterfactual: the merged `{ capture: true }` gives `{inner: 0, doc: 0}` (descendant handler killed); this PR gives `{inner: 1, doc: 0}` — descendant runs, delegated handler still blocked.
- Five simulated re-renders resetting `href` in place: re-patched to `?w=1` every time, **0** extra listeners added.
- Cross-origin `https://example.com/a/b/pull/1/files`: left untouched.
- Files page settled with **0** unpatched diff anchors and no page errors.
- Clicked the Files-changed tab: single full navigation straight to `?w=1`, no intermediate redirect — the #114 feature still works.

Worth noting that #3 is not hypothetical: instrumentation caught GitHub resetting
anchor `href`s in place 4-6 times per files-page load, so the merged code stacks a
listener on each one.

Refs #114
